### PR TITLE
Add ability to select letters for conversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ config.rb
 config.php
 warnings.txt
 
+# Ignore letters_selected.txt
+letters_selected.txt
+
 .DS_Store
 
 # some possible annotation file names

--- a/config.demo.rb
+++ b/config.demo.rb
@@ -5,6 +5,7 @@ $annotation_file = "#{File.dirname(__FILE__)}/annotations.xml"
 # loaded into the annotonia project
 # $letters_in = "/var/local/www/cocoon/annotonia/xml/letters"
 $letters_in = "#{File.dirname(__FILE__)}/letters_orig"
+$letters_in_selected = "#{File.dirname(__FILE__)}/letters_selected.txt"
 $letters_out = "#{File.dirname(__FILE__)}/letters_new"
 $warnings_file = "#{File.dirname(__FILE__)}/warnings.txt"
 

--- a/lib/annotation_manager.rb
+++ b/lib/annotation_manager.rb
@@ -107,7 +107,29 @@ class AnnotationManager
   end
 
   def create_letters
-    letter_paths = Dir.glob("#{$letters_in}/*")
+    letter_paths = []
+
+    if File.size?($letters_in_selected)
+      puts "Converting annotations from selected letters"
+
+      # Create list of selected letter file paths
+      IO.readlines("#{$letters_in_selected}").each do |letter|
+        letter_path = "#{$letters_in}/#{letter.chomp!}.xml"
+
+        if File.size?(letter_path)
+          letter_paths << letter_path
+        else
+          puts "Selected letter \"#{letter}\"'s file not present at: #{letter_path}"
+        end
+      end
+    else
+      puts "Converting annotations from all letters"
+      puts "  To select specific letters, list one letter filename per line"
+      puts "  in the file \"#{$letters_in_selected}\""
+
+      letter_paths = Dir.glob("#{$letters_in}/*")
+    end
+
     letter_paths.each do |path|
       annotations = find_annotations("@letter_id", path.match(/let[0-9]{4}/)[0])
       @letters << Letter.new(path, annotations)
@@ -179,7 +201,7 @@ class AnnotationManager
   end
 
   def prompt_input
-    puts "Running this script will remove files in the #{@output_dir} directory"
+    puts "Running this script will remove files in the #{$letters_out} directory"
     puts "and it will wipe the files #{$annotation_file} and #{$warnings_file}"
     puts "Continue?  y/N"
     return gets.chomp


### PR DESCRIPTION
Conversion now checks for selected letters file
whose path is defined as $letters_in_selected in config.rb
where each line is intended to be the file name of a selected letter
otherwise all letters' annotations are converted

Fix https://github.com/Willa-Cather-Archive/annotonia/issues/13