### PR TITLE
Skip XML output if tagged "Needs Correction"

### DIFF
--- a/lib/annotation_manager.rb
+++ b/lib/annotation_manager.rb
@@ -22,8 +22,17 @@ class AnnotationManager
     prompt_for_negation "Would you like to update and overwrite the annotations' TEI for reference in #{$annotation_file}?"
 
     create_annotations if !@flask_queried_bool
+
+    # Remove "Needs Correction" annotations
+    annotations = []
+    @flask_annotations.each do |anno|
+      if ! anno.tags.include? "Needs Correction"
+        annotations << anno
+      end
+    end
+
     # only grab annotations which have xml
-    annotations = @flask_annotations.map{ |anno| anno.xml }.compact
+    annotations = annotations.map{ |anno| anno.xml }.compact
     teimaker = TeiDocument.new(annotations)
     tei = teimaker.wrap
     File.write("#{$annotation_file}", tei.to_xml( indent: 4, encoding: "UTF-8" ))

--- a/test/annotation_manager_test.rb
+++ b/test/annotation_manager_test.rb
@@ -55,13 +55,20 @@ class TestAnnotationManager < Minitest::Test
     assert file_time < now+1
 
     # given that two of the annotations reference another
-    # there should be two less notes in the tei than in the annotations object
-    assert_equal @manager.flask_annotations.length-2, tei.css("note[type='annotation']").length
-    expected_text = %{<note type=\"annotation\" xml:id=\"aanno172\" target=\"anno172\" corresp=\"cat.let2161\">
-  <p>It's a state.<lb/><hi rend=\"italic\">Just a fact for you, about states</hi>.</p>
+    # and one with the "Needs Correction" tag is skipped
+    # there should be three less notes in the tei than the annotations object
+    assert_equal @manager.flask_annotations.length-3, tei.css("note[type='annotation']").length
+
+    expected_text = %q{<note type="annotation" xml:id="a000178" target="000178" corresp="cat.let2514">
+  <p>A recital series of chamber music given, at least in part, by the Hambourg Trio at the Jenkins Gallery in Toronto.</p>
 </note>}
+    tei_text = tei.css("note[target=\"000178\"]").to_s
+    assert_equal expected_text, tei_text
+
+    # Verify annotations tagged "Needs Correction" aren't included in TEI
+    expected_text = ""
     tei_text = tei.css("note[target=anno172]").to_s
-    assert_equal tei_text, expected_text
+    assert_equal expected_text, tei_text
 
     # verify that the reference annotations return the correct id
     anno = @manager.find_annotations("@id", "000178")[0]


### PR DESCRIPTION
Adjust expected values for test_create_annotation_xml

Flip "tei_text" and "expected_text" parameters to asset_equal,
so they match the "expected" and "actual" labels when not equal

Add test to ensure "Needs Correction" annotation is skipped

Close #8 