### PR TITLE
Remove non-underline style spans

### DIFF
--- a/lib/tei_annotation.rb
+++ b/lib/tei_annotation.rb
@@ -43,6 +43,9 @@ class TeiAnnotation
       # TODO what about video description?
       vid.replace("<media mimeType='video/mp4' url='#{source1.attribute("src")}' width='#{vid.attribute("width")}'/>")
     end
+
+    # Remove span tags with non-underline styles, keeping their contents
+    replace_open_close("span[style]", "", "")
   end
 
   private

--- a/test/tei_annotation_test.rb
+++ b/test/tei_annotation_test.rb
@@ -5,7 +5,7 @@ class TestTeiAnnotation < Minitest::Test
     start_text = %{
 <note>
 <p>This is a <i>test</i> of <br/> the <em>system</em>.</p>
-<p>It has some other stuff like lists</p>
+<p>It has some <span style="display: none;">other stuff</span> like lists</p>
 <ul><li>1</li><li>2</li></ul>
 <ol><li>1</li><li>2</li></ol>
 <p><span style="text-decoration: underline;">Underlined word!</span></p>


### PR DESCRIPTION
Add a span with style attribute to tei_annotation_test start text
This is removed so no change to after_text is necessary

Close #7 