### PR TITLE
Make API limit a config var; Add warnings to edit

### DIFF
--- a/config.demo.rb
+++ b/config.demo.rb
@@ -9,7 +9,11 @@ $letters_in_selected = "#{File.dirname(__FILE__)}/letters_selected.txt"
 $letters_out = "#{File.dirname(__FILE__)}/letters_new"
 $warnings_file = "#{File.dirname(__FILE__)}/warnings.txt"
 
-$flask_url = "path?limit=2000"
+# If limit changed, must also change:
+# RESULTS_MAX_SIZE in annotator-store/annotator/elasticsearch.py
+# $flask_results_max in annotonia-status/env/config.php
+$flask_limit = 10000
+$flask_url = "path?limit=#{$flask_limit}"
 $anno_store_url = "server/annostore/annotations/"
 $tei_ns = "http://www.tei-c.org/ns/1.0"
 

--- a/lib/annotation_manager.rb
+++ b/lib/annotation_manager.rb
@@ -208,6 +208,17 @@ class AnnotationManager
     url = id ? "#{$flask_url}&pageID=#{id}" : $flask_url
     res = Net::HTTP.get(URI.parse(URI.encode(url)))
     json = JSON.parse(res)
+
+    if json["total"] >= $flask_limit
+      puts "WARNING: ANNOTATOR-STORE RESULT LIMIT REACHED"
+      puts "Annotation TEI output will be missing annotations"
+      puts "We MUST update $flask_limit in config.rb and sync value with config variables in annotonia-status and annotator-store"
+    elsif json["total"].to_f / $flask_limit >= 0.9
+      puts "WARNING: Annotator-store limit almost reached"
+      puts "#{json["total"]} / #{$flask_limit}"
+      puts "Update $flask_limit in config.rb and sync value with config variables in annotonia-status and annotator-store soon"
+    end
+
     if json["rows"]
       @flask_queried_bool = true
       return json["rows"]


### PR DESCRIPTION
Print a warning when the result list of all annotations hits 90% of the
API limit, bolder text if the limit is hit

Close #17 